### PR TITLE
Display recommendations directly on dashboard

### DIFF
--- a/RECOMMENDATIONS_UPDATE.md
+++ b/RECOMMENDATIONS_UPDATE.md
@@ -1,0 +1,80 @@
+# Dashboard Recommendations Update
+
+## Overview
+Updated the trading agent dashboard to show recommendations directly on the watchlist instead of requiring users to click "Analyze" for each stock symbol.
+
+## Changes Made
+
+### 1. New API Endpoint (`app.py`)
+- **Added**: `/api/watchlist/recommendations` endpoint
+- **Purpose**: Returns recommendations for all watchlist symbols in a single request
+- **Features**:
+  - Batch analysis of all watchlist symbols
+  - Error handling for individual symbol analysis failures
+  - JSON serialization of numpy types
+  - Returns structured recommendation data including:
+    - Symbol and current price
+    - Action (BUY/SELL/HOLD)
+    - Confidence percentage
+    - Position size, stop loss, and take profit levels
+
+### 2. Updated Dashboard Template (`templates/dashboard.html`)
+
+#### CSS Styles Added
+- `.recommendation-badge`: Base styling for recommendation badges
+- `.recommendation-buy`: Green background for BUY recommendations
+- `.recommendation-sell`: Red background for SELL recommendations  
+- `.recommendation-hold`: Gray background for HOLD recommendations
+- `.recommendation-error`: Orange background for analysis errors
+- `.confidence-high`: Green text for high confidence (≥70%)
+- `.confidence-medium`: Orange text for medium confidence (40-69%)
+- `.confidence-low`: Red text for low confidence (<40%)
+
+#### JavaScript Updates
+- **Modified**: `refreshWatchlist()` function
+  - Now calls `/api/watchlist/recommendations` instead of `/api/watchlist`
+  - Displays comprehensive recommendation data in a table format
+  - Shows: Symbol, Price, Recommendation, Confidence, Position Size, Stop Loss, Take Profit
+  - Added `getConfidenceClass()` helper function for confidence styling
+
+#### UI Changes
+- **Updated**: Watchlist header from "Watchlist" to "Watchlist & Recommendations"
+- **Enhanced**: Table columns to show recommendation data directly
+- **Improved**: Visual feedback with color-coded badges and confidence indicators
+
+### 3. Data Structure
+The new recommendations endpoint returns data in this format:
+```json
+{
+  "recommendations": [
+    {
+      "symbol": "AAPL",
+      "current_price": 177.0,
+      "action": "HOLD",
+      "confidence": 67.0,
+      "position_size": 1000.0,
+      "stop_loss": 140.0,
+      "take_profit": 160.0,
+      "timestamp": "2024-01-01T00:00:00"
+    }
+  ]
+}
+```
+
+## Benefits
+
+1. **Improved User Experience**: Users can see all recommendations at a glance without clicking through each symbol
+2. **Better Performance**: Single API call instead of multiple analyze requests
+3. **Enhanced Visibility**: Color-coded badges make it easy to quickly identify trading opportunities
+4. **Comprehensive Data**: Shows confidence levels, position sizing, and risk management levels
+5. **Error Resilience**: Gracefully handles analysis failures for individual symbols
+
+## Usage
+
+The dashboard now automatically displays recommendations for all watchlist symbols. Users can:
+- See BUY/SELL/HOLD recommendations with confidence levels
+- View suggested position sizes and risk management levels
+- Click "Details" for in-depth analysis of specific symbols
+- Remove symbols from watchlist as before
+
+The recommendations refresh automatically every 10 seconds along with the rest of the dashboard data.

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -277,6 +277,48 @@
         .signal-hold {
             background: #95a5a6;
         }
+
+        .recommendation-badge {
+            padding: 6px 12px;
+            border-radius: 6px;
+            color: white;
+            font-size: 0.9em;
+            font-weight: bold;
+            text-align: center;
+            min-width: 80px;
+            display: inline-block;
+        }
+
+        .recommendation-buy {
+            background: #27ae60;
+        }
+
+        .recommendation-sell {
+            background: #e74c3c;
+        }
+
+        .recommendation-hold {
+            background: #95a5a6;
+        }
+
+        .recommendation-error {
+            background: #f39c12;
+        }
+
+        .confidence-high {
+            color: #27ae60;
+            font-weight: bold;
+        }
+
+        .confidence-medium {
+            color: #f39c12;
+            font-weight: bold;
+        }
+
+        .confidence-low {
+            color: #e74c3c;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -336,10 +378,10 @@
             </div>
         </div>
 
-        <!-- Watchlist -->
+        <!-- Watchlist with Recommendations -->
         <div class="table-container" style="margin-top: 20px;">
             <div class="card-header">
-                Watchlist
+                Watchlist & Recommendations
                 <button class="refresh-btn" onclick="refreshWatchlist()">Refresh</button>
             </div>
             
@@ -653,7 +695,7 @@
 
         async function refreshWatchlist() {
             try {
-                const response = await fetch('/api/watchlist');
+                const response = await fetch('/api/watchlist/recommendations');
                 const data = await response.json();
                 
                 if (data.error) {
@@ -661,7 +703,7 @@
                     return;
                 }
 
-                if (!data.watchlist || data.watchlist.length === 0) {
+                if (!data.recommendations || data.recommendations.length === 0) {
                     document.getElementById('watchlist-table').innerHTML = '<div class="loading">No symbols in watchlist</div>';
                     return;
                 }
@@ -671,19 +713,42 @@
                         <thead>
                             <tr>
                                 <th>Symbol</th>
-                                <th>Action</th>
+                                <th>Price</th>
+                                <th>Recommendation</th>
+                                <th>Confidence</th>
+                                <th>Position Size</th>
+                                <th>Stop Loss</th>
+                                <th>Take Profit</th>
+                                <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody>
                 `;
 
-                data.watchlist.forEach(symbol => {
+                data.recommendations.forEach(rec => {
+                    const actionClass = rec.action ? `recommendation-${rec.action.toLowerCase()}` : 'recommendation-hold';
+                    const confidenceClass = getConfidenceClass(rec.confidence);
+                    
                     tableHtml += `
                         <tr>
-                            <td><strong>${symbol}</strong></td>
+                            <td><strong>${rec.symbol}</strong></td>
+                            <td>$${rec.current_price ? rec.current_price.toFixed(2) : 'N/A'}</td>
                             <td>
-                                <button class="btn" style="background: #3498db; color: white; padding: 4px 8px; font-size: 0.8em;" onclick="analyzeSymbol('${symbol}')">Analyze</button>
-                                <button class="btn" style="background: #e74c3c; color: white; padding: 4px 8px; font-size: 0.8em;" onclick="removeFromWatchlist('${symbol}')">Remove</button>
+                                <span class="recommendation-badge ${actionClass}">
+                                    ${rec.action || 'HOLD'}
+                                </span>
+                            </td>
+                            <td>
+                                <span class="${confidenceClass}">
+                                    ${rec.confidence ? rec.confidence.toFixed(1) : 'N/A'}%
+                                </span>
+                            </td>
+                            <td>$${rec.position_size ? rec.position_size.toFixed(2) : 'N/A'}</td>
+                            <td>$${rec.stop_loss ? rec.stop_loss.toFixed(2) : 'N/A'}</td>
+                            <td>$${rec.take_profit ? rec.take_profit.toFixed(2) : 'N/A'}</td>
+                            <td>
+                                <button class="btn" style="background: #3498db; color: white; padding: 4px 8px; font-size: 0.8em;" onclick="analyzeSymbol('${rec.symbol}')">Details</button>
+                                <button class="btn" style="background: #e74c3c; color: white; padding: 4px 8px; font-size: 0.8em;" onclick="removeFromWatchlist('${rec.symbol}')">Remove</button>
                             </td>
                         </tr>
                     `;
@@ -694,6 +759,13 @@
             } catch (error) {
                 document.getElementById('watchlist-table').innerHTML = `<div class="error">Error loading watchlist</div>`;
             }
+        }
+
+        function getConfidenceClass(confidence) {
+            if (!confidence) return 'confidence-low';
+            if (confidence >= 70) return 'confidence-high';
+            if (confidence >= 40) return 'confidence-medium';
+            return 'confidence-low';
         }
 
         async function refreshMarketMovers() {


### PR DESCRIPTION
Display stock recommendations directly on the dashboard watchlist to improve user experience and performance.

This is achieved by adding a new API endpoint to fetch all watchlist recommendations in a single call and updating the dashboard to render this data directly in the watchlist table, replacing individual 'Analyze' buttons with comprehensive, real-time insights.

---
<a href="https://cursor.com/background-agent?bcId=bc-37fcc1ab-abbb-4bbf-bd44-3322cbb1d847">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37fcc1ab-abbb-4bbf-bd44-3322cbb1d847">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

