### PR TITLE
Fix undefined macd_bearish error

### DIFF
--- a/trading_strategy.py
+++ b/trading_strategy.py
@@ -83,6 +83,8 @@ class TradingStrategy:
         # MACD analysis
         macd_bullish = (latest.get('MACD', 0) > latest.get('MACD_Signal', 0) and
                        latest.get('MACD_Histogram', 0) > 0)
+        macd_bearish = (latest.get('MACD', 0) < latest.get('MACD_Signal', 0) and
+                       latest.get('MACD_Histogram', 0) < 0)
         
         # Price momentum (5-period rate of change)
         if len(data) >= 5:


### PR DESCRIPTION
Fix `NameError` for `macd_bearish` by adding its definition.

The `macd_bearish` variable was used in a conditional statement but was never initialized, leading to a runtime error. This PR adds the missing definition, mirroring the existing `macd_bullish` logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce8614c8-a4e6-4508-a4b4-fd1b1cfe266d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce8614c8-a4e6-4508-a4b4-fd1b1cfe266d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

